### PR TITLE
Log system

### DIFF
--- a/awsgitops/generators/dummy.py
+++ b/awsgitops/generators/dummy.py
@@ -2,7 +2,7 @@ import sys
 from .spec import spec
 from ..modules import util
 from time import sleep
-from .genlauncher import Status
+from .genlauncher import Status, LogType
 
 # Example class that doesn't access any AWS instances
 class dummy(spec):
@@ -19,8 +19,9 @@ class dummy(spec):
     def is_operational(cls):
         cls.set_status(Status.OPERATIONAL, "Checking") 
         sleep(2)
-        if input('\033[2K' + "Fail this step? (y/n)\n").lower() == "y":
+        if input("Fail this step? (y/n) ").lower() == "y":
             cls.set_status(Status.OPERATIONAL, "Failed")
+            cls.log_put(LogType.ERROR, "Aborted")
             return False
         else:
             cls.set_status(Status.OPERATIONAL, "Successful")

--- a/awsgitops/generators/genlauncher.py
+++ b/awsgitops/generators/genlauncher.py
@@ -12,22 +12,28 @@ class Status(Enum):
      GENERATE = 5
      FAILED = 6
 
+class LogType(Enum):
+    ERROR = 1
+    WARNING = 2
+    MESSAGE = 3
+
 # Dynamically load generator classes and autopopulate the status dict
 def load_generators(generator_config):
     generators = {module_name: getattr(importlib.import_module(f"awsgitops.generators.{module_name}"), module_name) for module_name in generator_config.keys() if module_name != "CONFIG"}
 
     status = {Status.STATUS: "Not Started", Status.GET_INST: "", Status.OPERATIONAL: "", Status.GET_DATA: "", Status.GENERATE: "", Status.FAILED: False}
     statuses = {generator: deepcopy(status) for generator in generators.keys() if generator != "CONFIG"}
+    log = []
 
-    return generators, statuses
+    return generators, statuses, log
 
 # Configure the generator classes with status object, mutex, config, and yaml list and return a list of threads ready to run
-def configure_generators(generators, statuses, generator_config, yamls):
+def configure_generators(generators, statuses, log, generator_config, yamls):
     mutex = Lock()
     threads = []
     
     for generator in generators.values():
-        generator.config(generator_config, statuses, mutex)
+        generator.config(generator_config, log, statuses, mutex)
         threads.append(Thread(target=generator.run, args=(yamls,)))
 
     return threads

--- a/awsgitops/generators/spec.py
+++ b/awsgitops/generators/spec.py
@@ -1,9 +1,10 @@
 import sys
 from ..modules import util
-from .genlauncher import Status
+from .genlauncher import Status, LogType
 
 class spec():
     status = None
+    log = None
     confg = None
     yaml_lock = None
 
@@ -32,7 +33,7 @@ class spec():
     def run(cls, yamls):
         for yaml in yamls:
             cls.reset()
-            if cls.status == None or cls.config == None or cls.yaml_lock == None:
+            if cls.status == None or cls.config == None or cls.yaml_lock == None or cls.log == None:
                 util.error(f"Generator {__class__.__name__} has not been fully configured")    
 
             stages = (("Running getInstance", cls.get_instance, []), ("Running isOperational", cls.is_operational, []), ("Running getData", cls.get_data, []), ("Running generateYaml", cls.generate_yaml, [yaml])) 
@@ -54,8 +55,9 @@ class spec():
 
     # Configure the generator class
     @classmethod
-    def config(cls, generator_config, status_object, mutex):
+    def config(cls, generator_config, log, status_object, mutex):
         cls.config = generator_config
+        cls.log = log
         cls.status = status_object
         cls.yaml_lock = mutex
 
@@ -65,4 +67,9 @@ class spec():
         cls.set_status(Status.STATUS, "Started")
         for status in [Status.GET_INST, Status.OPERATIONAL, Status.GET_DATA, Status.GENERATE]:
              cls.set_status(status, "Waiting")
+
+    # Log messages
+    @classmethod
+    def log_put(cls, type, message):
+        cls.log.append((type, f"{cls.__name__}|{message}"))
 


### PR DESCRIPTION
Added an async logging system that uses a shared list to the generators that logs can be appended to as a queue. Logs are tuples of a log type and message. Logs can be read from the queue by poping the first element in the list. Appropriate formating function also added.
Closes #8 
